### PR TITLE
add check-data-authenticity to notify-about-payment ns

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,7 @@
                  [org.clojure/core.async "0.2.374"]
                  [metosin/compojure-api "1.1.0"]
                  [weareswat/request-utils "0.1.0"]
-                 [weareswat/clj-meowallet "0.4.0"]
+                 [weareswat/clj-meowallet "0.5.0"]
                  [prismatic/schema "1.1.1"]
                  [com.taoensso/timbre "4.3.1"]
                  [prismatic/schema "1.1.1"]

--- a/test/weareswat/meowallet_integration/core/notify_about_payment_test.clj
+++ b/test/weareswat/meowallet_integration/core/notify_about_payment_test.clj
@@ -1,7 +1,7 @@
 (ns weareswat.meowallet-integration.core.notify-about-payment-test
   (:use clojure.test)
   (:require [weareswat.meowallet-integration.core.notify-about-payment :as notify-about-payment]
-            [clojure.core.async :refer [<!!]]
+            [clojure.core.async :refer [<!! go]]
             [environ.core :refer [env]]
             [result.core :as result]
             [request-utils.core :as request-utils]))
@@ -37,12 +37,22 @@
 
 (deftest transform-data-test
   (with-redefs [request-utils/http-post (fn [url] {:success true
-                                                   :status 200})]
-    (let [input-data {:operation-status "COMPLETED"
+                                                   :status 200})
+                notify-about-payment/check-data-authenticity (fn [data]
+                                                               (go {:success true
+                                                                    :status 200}))]
+    (let [input-data {:currency "EUR"
                       :amount 10
-                      :currency "EUR"
-                      :operation-id "qwkjehqkjwhe"}
-          result (notify-about-payment/run! {} input-data)]
+                      :event "COMPLETED"
+                      :ext-customerid "00001"
+                      :ext-email "noreply@sapo.pt"
+                      :ext-invoiceid "38440200100"
+                      :method "WALLET"
+                      :operation-id "qwkjehqkjwhe"
+                      :operation-status "COMPLETED"
+                      :user "237"}
+
+          result (<!! (notify-about-payment/run! {} input-data))]
 
         (is (result/succeeded? result))
         (is (= 200 (:status result))))))


### PR DESCRIPTION
Completed the case of notify-about-payment, which has the following
steps:
- check-data-authenticity by using `clj-meowallet` library
- transform-data to some format that payment-gateway could understand
- send the transformed data to the payment-gateway

Added a full test using mocked requests. I would like to add some
end-to-end tests. next steps :)
