### PR TITLE
Added the an handler to deal with meowallet callbacks.

### DIFF
--- a/src/weareswat/meowallet_integration/handlers/notify_about_payment.clj
+++ b/src/weareswat/meowallet_integration/handlers/notify_about_payment.clj
@@ -1,0 +1,17 @@
+(ns weareswat.meowallet-integration.handlers.notify-about-payment
+  "Controller to handle the root/payment-reference/event
+   This handler should be called by meowallet when the state of some mb-reference
+   changed, to paid, expired.. Here we just receive te request, convert the related
+   data and sends it to the payment-service"
+  (:require [clanhr.reply.core :as reply]
+            [clanhr.reply.json :as json]
+            [clojure.core.async :refer [<!]]
+            [weareswat.meowallet-integration.core.notify-about-payment :as notify-about-payment]))
+
+(defn handle
+  "Runs a root/payment-reference/event route"
+  [request]
+  (reply/async-reply
+    (let [data (json/build (slurp (:body request)))
+          result (<! (notify-about-payment/run! (:context request) data))]
+      (reply/result result))))

--- a/src/weareswat/meowallet_integration/routes.clj
+++ b/src/weareswat/meowallet_integration/routes.clj
@@ -8,6 +8,7 @@
     [result.core :as result]
     [weareswat.meowallet-integration.models.payment-reference-request :as prr]
     [weareswat.meowallet-integration.handlers.generate-mb-ref :as generate-mb-ref]
+    [weareswat.meowallet-integration.handlers.notify-about-payment :as notify-about-payment]
     [weareswat.meowallet-integration.handlers.index :as index]))
 
 (def sweet-public-routes
@@ -33,6 +34,14 @@
                 :summary "Request MEOWallet for MB Reference"
                 :description "Returns MB Reference related data"
                 (generate-mb-ref/handle request)
+      )
+    (sweet/POST "/payment-reference/event" request
+                :body [input s/Any]
+                :return s/Any
+                :summary "Webhood called by meowallet"
+                :description "Webhook to be notified when the state of some mb-reference changed.
+                              This endpoint should be called by meowallet"
+                (notify-about-payment/handle request)
       ))
   )
 

--- a/test/weareswat/meowallet_integration/handlers/notify_about_payment_test.clj
+++ b/test/weareswat/meowallet_integration/handlers/notify_about_payment_test.clj
@@ -1,0 +1,52 @@
+(ns weareswat.meowallet-integration.handlers.notify-about-payment-test
+  (:use clojure.test)
+  (:require [weareswat.meowallet-integration.handlers.test-request :as test-request]
+            [environ.core :refer [env]]
+            [weareswat.meowallet-integration.core.notify-about-payment :as notify-about-payment]
+            [clojure.core.async :refer [go]]
+            [request-utils.core :as request-utils]
+            [result.core :as result]))
+
+(deftest basic-test
+  (testing "root/payment-reference/event returns OK"
+    (with-redefs [request-utils/http-post (fn [url] {:success true
+                                                     :status 200})
+                 notify-about-payment/check-data-authenticity (fn [data]
+                                                                (go {:success true
+                                                                     :status 200}))]
+      (let [body {:currency "EUR"
+                  :amount 10
+                  :event "COMPLETED"
+                  :ext-customerid "00001"
+                  :ext-email "noreply@sapo.pt"
+                  :ext-invoiceid "38440200100"
+                  :method "WALLET"
+                  :operation-id "qwkjehqkjwhe"
+                  :operation-status "COMPLETED"
+                  :user "237"}
+            response (test-request/parsed-response :post
+                                                   "/payment-reference/event"
+                                                   body)]
+        (is (= 200 (:status response))))))
+
+  (testing "/payment-reference/create returns OK"
+    (with-redefs [request-utils/http-post (fn [url] {:success true
+                                                     :status 200})
+                 notify-about-payment/check-data-authenticity (fn [data]
+                                                                (go {:success false
+                                                                     :status 400}))]
+      (let [body {:currency "EUR"
+                  :amount 10
+                  :event "COMPLETED"
+                  :ext-customerid "00001"
+                  :ext-email "noreply@sapo.pt"
+                  :ext-invoiceid "38440200100"
+                  :method "WALLET"
+                  :operation-id "qwkjehqkjwhe"
+                  :operation-status "COMPLETED"
+                  :user "237"}
+            response (test-request/parsed-response :post
+                                                   "/payment-reference/create"
+                                                   body)]
+        (is (= 400 (:status response)))))
+    ))


### PR DESCRIPTION
This handles `root/payment-reference/event` path. This endpoint should
only be called by meowallet to notify us about some state changes on
some mb-reference.

We receive the request, validate it's authenticity, transforms the data
and sends it to the payment-gateway.
