### PR TITLE
format expires data

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -11,6 +11,7 @@
                  [org.clojure/core.async "0.2.374"]
                  [metosin/compojure-api "1.1.0"]
                  [weareswat/request-utils "0.1.0"]
+                 [clj-time "0.11.0"]
                  [weareswat/clj-meowallet "0.6.0"]
                  [prismatic/schema "1.1.1"]
                  [com.taoensso/timbre "4.3.1"]

--- a/src/weareswat/meowallet_integration/core/generate_mb_ref.clj
+++ b/src/weareswat/meowallet_integration/core/generate_mb_ref.clj
@@ -1,8 +1,17 @@
 (ns weareswat.meowallet-integration.core.generate-mb-ref
   (:require [result.core :as result]
             [clojure.core.async :refer [go <!]]
+            [clj-time.format :as f]
+            [clj-time.coerce :as c]
             [weareswat.meowallet-integration.models.payment-reference-request :as prr]
             [clj-meowallet.core :as meowallet]))
+
+(def custom-formatter (f/formatter "yyyy-MM-dd'T'HH:mm:ss+0000"))
+
+(defn date->meowallet-date
+  [date]
+  (when date
+    (f/unparse custom-formatter (c/from-string date))))
 
 (defn transform-input-data
   [context]
@@ -10,7 +19,7 @@
     {:credentials {:meo-wallet-api-key (get-in context [:supplier :api-key])}
      :data {:amount (:amount context)
             :currency (:currency context)
-            :expires (:expires-at context)}}))
+            :expires (date->meowallet-date (:expires-at context))}}))
 
 (defn transform-output-data
   [result]


### PR DESCRIPTION
Meowallet only accepts a specific format of expires data which is:

`yyyy-MM-dd'T'HH:mm:ss+0000`

So this PR is converting the expires date to meo-wallet format
