### PR TITLE
Return mb reference as "reference" instead od "ref"

### DIFF
--- a/src/weareswat/meowallet_integration/core/generate_mb_ref.clj
+++ b/src/weareswat/meowallet_integration/core/generate_mb_ref.clj
@@ -32,7 +32,7 @@
      :expires-at (:expires result)
      :transaction-id (:id result)
      :status (:status result)
-     :mb {:ref (get-in result [:mb :ref])
+     :mb {:reference (get-in result [:mb :ref])
           :entity (get-in result [:mb :entity])
           :amount (:amount result)}}))
 

--- a/test/weareswat/meowallet_integration/core/generate_mb_ref_test.clj
+++ b/test/weareswat/meowallet_integration/core/generate_mb_ref_test.clj
@@ -90,7 +90,7 @@
 
       (testing "ref"
         (is (= (get-in meo-result-data [:mb :ref])
-               (get-in result [:mb :ref]))))
+               (get-in result [:mb :reference]))))
 
       (testing "entity"
         (is (= (get-in meo-result-data [:mb :entity])
@@ -143,7 +143,7 @@
           (is (:mb result))
 
           (testing "ref"
-            (is (get-in result [:mb :ref])))
+            (is (get-in result [:mb :reference])))
 
           (testing "entity"
             (is (get-in result [:mb :entity])))
@@ -192,7 +192,7 @@
           (is (:mb result))
 
           (testing "ref"
-            (is (get-in result [:mb :ref])))
+            (is (get-in result [:mb :reference])))
 
           (testing "entity"
             (is (get-in result [:mb :entity])))


### PR DESCRIPTION
This is to uniformize the names with the main service.
