### PR TITLE
Cleanup integration and consider request-utils

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ pom.xml.asc
 .lein-plugins/
 .lein-failures
 .nrepl-port
+.ruby-version

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject weareswat/meowallet-integration "0.3.0"
+(defproject weareswat/meowallet-integration "0.3.1"
   :description "Meowallet integration"
   :url "https://github.com/weareswat/meowallet-integration"
 
@@ -10,7 +10,7 @@
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/core.async "0.2.374"]
                  [metosin/compojure-api "1.1.0"]
-                 [weareswat/request-utils "0.1.0"]
+                 [weareswat/request-utils "0.4.0"]
                  [clj-time "0.11.0"]
                  [clanhr/analytics "1.11.0"]
                  [weareswat/clj-meowallet "0.6.0"]

--- a/src/weareswat/meowallet_integration/core/generate_mb_ref.clj
+++ b/src/weareswat/meowallet_integration/core/generate_mb_ref.clj
@@ -39,7 +39,11 @@
 
 (defn generate-mb-ref
   [credentials data]
-  (meowallet/generate-mb-ref credentials data))
+  (go
+    (result/on-success [response (<! (meowallet/generate-mb-ref credentials data))]
+      (result/success (if-let [body (:body response)]
+                        body
+                        response)))))
 
 (defn run
   [context data]

--- a/src/weareswat/meowallet_integration/core/simulator.clj
+++ b/src/weareswat/meowallet_integration/core/simulator.clj
@@ -19,12 +19,10 @@
                   :supplier-id "MeoWallet"
                   :operation_id (:transaction-id data)
                   :operation_status "COMPLETED"}]
-    (prn (str "I'll do a request with this data: " new-data))
     (result/success new-data)))
 
 (defn simulate-request
   [context data]
-  (prn (str "LET'S SIMULATE: " (assoc context :verify-cb (fn [auth-token url] (go {:success true :status 200})))))
   (-> (assoc context :verify-cb (fn [auth-token url] (go {:success true :status 200})))
       (notify-about-payment/run! (transform-data data))))
 


### PR DESCRIPTION
Sometimes the `meowallet/generate-mb-ref` returns a new request-utils
response with the date inside :body. Sometimes returns body. I tried to
understand why but I could not make all this return body (as it
should). So I did a martelate and check if the response has a body.